### PR TITLE
fix: add define macro for py tool

### DIFF
--- a/cyber/python/internal/py_cyber.cc
+++ b/cyber/python/internal/py_cyber.cc
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 using apollo::cyber::Node;

--- a/cyber/python/internal/py_parameter.cc
+++ b/cyber/python/internal/py_parameter.cc
@@ -19,6 +19,8 @@
 #include <set>
 #include <string>
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include "cyber/python/internal/py_cyber.h"
 

--- a/cyber/python/internal/py_record.cc
+++ b/cyber/python/internal/py_record.cc
@@ -19,6 +19,8 @@
 #include <set>
 #include <string>
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 using apollo::cyber::record::PyRecordReader;

--- a/cyber/python/internal/py_time.cc
+++ b/cyber/python/internal/py_time.cc
@@ -19,6 +19,8 @@
 #include <set>
 #include <string>
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 using apollo::cyber::PyDuration;

--- a/cyber/python/internal/py_timer.cc
+++ b/cyber/python/internal/py_timer.cc
@@ -19,6 +19,8 @@
 #include <set>
 #include <string>
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 using apollo::cyber::PyTimer;


### PR DESCRIPTION
- avoid error below
```
E20240722 23:49:33.490810 124251474656320 py_cyber.cc:46] []cyber_py_init:PyArg_ParseTuple failed!
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/daisuke/workspace/core/./bazel-bin/cyber/tools/cyber_node/cyber_node.runfiles/_main/cyber/tools/cyber_node/cyber_node.py", line 115, in <module>
    cyber.init()
  File "/home/daisuke/workspace/core/bazel-bin/cyber/tools/cyber_node/cyber_node.runfiles/_main/cyber/python/cyber_py3/cyber.py", line 51, in init
    return _CYBER.py_init(module_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
SystemError: <built-in function py_init> returned a result with an exception set
```